### PR TITLE
Use python3 by environment instead of hard-coding a full path

### DIFF
--- a/msg2eml.py
+++ b/msg2eml.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # Referencecs:
 


### PR DESCRIPTION
Use python3 by environment instead of hard-coding a full path